### PR TITLE
Added support for mounting host directory for output files from nmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM progrium/busybox
 
 RUN opkg-install nmap
+RUN mkdir /data
+VOLUME /data
+WORKDIR /data
+
 ENTRYPOINT ["nmap"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Docker image is based on the [progrium/busybox](https://registry.hub.docker
 ## How to use this image
 
 ```
-docker run --rm uzyexe/nmap [Scan Type(s)] [Options] {target specification}
+docker run --rm -v "$(pwd)":/data uzyexe/nmap [Scan Type(s)] [Options] {target specification}
 ```
 
 ### Case 1: Simple Scan


### PR DESCRIPTION
Hey!

Found your NMAP docker image to be a really great tool, but I needed to have the output from NMAP in a file format, so I needed to have the container bind to a local directory. As you can see from the edited README.md I just used the directory in which I ran the docker run command. 

I figured I'd make a pull-request for a feature update for the volume support, as I'm sure others need that as well.

Hope you like the addition!

Regards

Hakash